### PR TITLE
Added Torbox Media Center

### DIFF
--- a/apps/torbox-media-center/.env
+++ b/apps/torbox-media-center/.env
@@ -1,0 +1,2 @@
+TORBOX_API_KEY=
+TORBOX_MOUNT_METHOD=strm #strm by default, fuse for alternative

--- a/apps/torbox-media-center/compose.yaml
+++ b/apps/torbox-media-center/compose.yaml
@@ -1,0 +1,39 @@
+services:
+  torbox-media-center:
+      # build:
+      #   context: https://github.com/TorBox-App/torbox-media-center.git
+      #   #dockerfile: dockerfile
+      #   dockerfile_inline: |
+      #     FROM --platform=linux/arm64 python:3.10.12-bookworm
+
+      #     WORKDIR /app
+      #     COPY requirements.txt .
+
+      #     RUN pip install --no-cache-dir -r requirements.txt
+
+      #     COPY . .
+
+      #     ENV TORBOX_API_KEY=
+      #     ENV MOUNT_METHOD=strm
+      #     ENV MOUNT_PATH=/torbox
+
+      #     CMD ["python", "main.py"]
+      image: mikewazar/torbox-media-center:latest
+      container_name: torbox-media-center
+      stdin_open: true
+      tty: true
+      restart: unless-stopped
+      volumes:
+            - ${DOCKER_DATA_DIR}/torbox:/torbox
+      environment:
+            - TORBOX_API_KEY=${TORBOX_API_KEY}
+            - MOUNT_METHOD=${TORBOX_MOUNT_METHOD}
+            - MOUNT_PATH=/torbox
+      labels:
+        - "traefik.enable=true"
+        - "traefik.http.routers.torboxmedia.rule=Host(`${TORBOX_MEDIA_CENTER_HOSTNAME?}`)"
+        - "traefik.http.routers.torboxmedia.entrypoints=websecure"
+        - "traefik.http.routers.torboxmedia.tls.certresolver=letsencrypt"
+      profiles:
+        - debrid_media_server
+        - all

--- a/apps/torbox-media-center/compose.yaml
+++ b/apps/torbox-media-center/compose.yaml
@@ -1,24 +1,6 @@
 services:
   torbox-media-center:
-      # build:
-      #   context: https://github.com/TorBox-App/torbox-media-center.git
-      #   #dockerfile: dockerfile
-      #   dockerfile_inline: |
-      #     FROM --platform=linux/arm64 python:3.10.12-bookworm
-
-      #     WORKDIR /app
-      #     COPY requirements.txt .
-
-      #     RUN pip install --no-cache-dir -r requirements.txt
-
-      #     COPY . .
-
-      #     ENV TORBOX_API_KEY=
-      #     ENV MOUNT_METHOD=strm
-      #     ENV MOUNT_PATH=/torbox
-
-      #     CMD ["python", "main.py"]
-      image: mikewazar/torbox-media-center:latest
+      image: anonymoussystems/torbox-media-center:main
       container_name: torbox-media-center
       stdin_open: true
       tty: true


### PR DESCRIPTION
This adds https://github.com/TorBox-App/torbox-media-center to the compose stack.

By default, it uses' Mike's image that's built specifically for ARM64, as the official image on Docker Hub presently only supports AMD64. It also includes the dockerfile if someone wants to build it for AMD64 until the Torbox team updates the official packages with both options. 